### PR TITLE
chore: remove phantomjs support

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -137,7 +137,6 @@ module.exports = function(config) {
     // - Firefox
     // - Opera (has to be installed with `npm install karma-opera-launcher`)
     // - Safari (only Mac; has to be installed with `npm install karma-safari-launcher`)
-    // - PhantomJS
     // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
     browsers: ['ChromeHeadless', 'FirefoxHeadless'],
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "karma-googmodule-preprocessor": "^1.0.1",
     "karma-jasmine": "^0.1.0",
     "karma-junit-reporter": "^1.2.0",
-    "karma-phantomjs-launcher": "^1.0.2",
     "mkdirp": "^0.5.1",
     "modernizr": "~3.3.1",
     "node-sass": "^4.12.0",


### PR DESCRIPTION
No longer supported, not used.